### PR TITLE
Use roleManagement instead of directory

### DIFF
--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -39,7 +39,7 @@
       },
       {
         "resource": "Microsoft Graph",
-        "scope": "Directory.Read.All"
+        "scope": "RoleManagement.Read.Directory"
       }
     ]
   },


### PR DESCRIPTION
Directory read all give the ability to read all the directory (User, group, role, etc)

Switching to RoleManagement because it only give the ability to read the RBAC role of directory.